### PR TITLE
API for Fetching Data from Mongo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ repeaters_gmrs_bulk.json
 /node_modules/
 package-lock.json
 package.json
+/data/repeaters_ham_bulk.json

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Signal Scout currently only includes VHF, UHF, and GMRS repeater information. Re
 #### Explore React Leaflet
 - Enable users to select from variety of basemaps
 ### Other
+- Convert code base to Typescript
 - Leverage JS code standardization tool such as Prettier or ESLint
 
 ## Data Sources

--- a/README.md
+++ b/README.md
@@ -29,10 +29,7 @@ Signal Scout currently only includes VHF, UHF, and GMRS repeater information. Re
 - Develop RESTful API to handle CRUD opertaions
   - ~~Implement with Express.js or similar~~
   - ~~Fetch data from API in main.js~~
-  - Create
-  - ~~Read~~
-  - Update
-  - Delete
+  - Create, ~~Read~~, Update, Delete
 ### Data Retrieval
 - Fetch data from APIs if not found locally
   - Fetch only data within user's current map extent
@@ -42,7 +39,7 @@ Signal Scout currently only includes VHF, UHF, and GMRS repeater information. Re
 - Leverage JS code standardization tool such as Prettier or ESLint
 
 ## Data Sources
-- Liveine Central API
+- Levine Central API
   - https://www.levinecentral.com/repeaters/repeater_fetch.php?
 - MyGMRS API
   - https://api.mygmrs.com/repeaters?

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Signal Scout currently only includes VHF, UHF, and GMRS repeater information. Re
 - Enable users to select from variety of basemaps
 ### Other
 - Convert code base to Typescript
+- Automate deployment of Signal Scout
 - Leverage JS code standardization tool such as Prettier or ESLint
 
 ## Data Sources

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Signal Scout currently only includes VHF, UHF, and GMRS repeater information. Re
 - Fetch data from APIs if not found locally
   - Fetch only data within user's current map extent
 ### Widgets
+#### Explore React Leaflet
 - Enable users to select from variety of basemaps
 ### Other
 - Leverage JS code standardization tool such as Prettier or ESLint

--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,7 @@ const HAM_ENDPOINT = 'http://localhost:3000/api/ham_repeaters'
 const GMRS_ENDPOINT = 'http://localhost:3000/api/gmrs_repeaters'
 
 // Initialize the Leaflet map
-const map = L.map('map').setView([38.95, -77.45], 10); // Centering on Dulles Airport
+const map = L.map('map').setView([39.0, -78.3], 7); // Centering on Dulles Airport
 
 // Add OpenStreetMap tile layer
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {


### PR DESCRIPTION
This PR introduces a backend server using Node which provides a simple API for fetching data from Mongo. The API endpoints exposed in this PR include:
- `GET /api/ham_repeaters`
- `GET /api/gmrs_repeaters`
`Mongoose` is used to create the Schemas and Models for each Mongo collection.
- MongoDB connection using Mongoose
- 2 API endpoints to server repeater data
- CORS to support communication between the front and backend