### PR TITLE
Display digipeaters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ repeaters_gmrs_bulk.json
 package-lock.json
 package.json
 /data/repeaters_ham_bulk.json
+/data/repeaters_digipeaters.geojson
+/data/repeaters_digipeaters.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ham and GMRS repeaters in one map! Signal Scout aims to reduce time and effort required for radio users to select their loadout.
 
-![Snip of SignalScout UI](./signalscout-page.png)
+![Signal Scout Demo](./signal_scout_demo.gif)
 
 ## Overview
 

--- a/js/main.js
+++ b/js/main.js
@@ -32,8 +32,12 @@ fetch(HAM_ENDPOINT)
     
             // Create a marker for each repeater
             const marker = L.circleMarker([lat, lon], {
-                radius: 8, fillColor: "#0000FF", color: "#000000",
-                weight: 1, opacity: 1, fillOpacity: 0.8
+                radius: 8,
+                fillColor: "red",
+                color: "black",
+                weight: 1,
+                opacity: 1,
+                fillOpacity: 0.8
             }).bindPopup(`
                 <strong>${Callsign || "Callsign Unknown"}</strong><br>
                 ${City + ", " + State}<br>
@@ -56,8 +60,12 @@ fetch(GMRS_ENDPOINT)
             const { Name, State, Latitude, Longitude, Frequency, Type, Status } = repeater;
 
             const marker = L.circleMarker([Latitude, Longitude], {
-                radius: 8, fillColor: "#FF0000", color: "#000000",
-                weight: 1, opacity: 1, fillOpacity: 0.8
+                radius: 8,
+                fillColor: "blue",
+                color: "black",
+                weight: 1,
+                opacity: 1,
+                fillOpacity: 0.8
             }).bindPopup(
                 `<strong>${Name || "Name Unknown"}</strong><br>
                 Frequency: ${Frequency}<br>
@@ -82,12 +90,12 @@ fetch(DIGI_ENDPOINT)
               if (feature.properties) {
                 // Create a popup content from digipeater properties
                 const popupContent = `
-                  <strong>Call Sign:</strong> ${feature.properties.call}<br>
-                  <strong>Last Heard:</strong> ${feature.properties.lastheard}<br>
-                  <strong>Port:</strong> ${feature.properties.ports}<br>
-                  <strong>Grid:</strong> ${feature.properties.grid}<br>
-                  <strong>SSID:</strong> ${feature.properties.ssid || 'N/A'}<br>
-                  <strong>Heard:</strong> ${feature.properties.heard ? 'Yes' : 'No'}
+                  <strong>${feature.properties.call}</strong><br>
+                  Last Heard: ${feature.properties.lastheard}<br>
+                  Port: ${feature.properties.ports}<br>
+                  Grid: ${feature.properties.grid}<br>
+                  SSID: ${feature.properties.ssid || 'N/A'}<br>
+                  Heard: ${feature.properties.heard ? 'Yes' : 'No'}
                 `;
                 layer.bindPopup(popupContent); // Bind the popup to the marker
               }
@@ -97,7 +105,8 @@ fetch(DIGI_ENDPOINT)
             pointToLayer: function (feature, latlng) {
                 return L.circleMarker(latlng, {
                   radius: 8,
-                  color: 'orange',
+                  color: 'black',
+                  fillColor: 'orange',
                   weight: 1,
                   opacity: 1,
                   fillOpacity: 0.8

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,7 @@
 // Initialize local data file paths
 const HAM_ENDPOINT = 'http://localhost:3000/api/ham_repeaters'
 const GMRS_ENDPOINT = 'http://localhost:3000/api/gmrs_repeaters'
+const DIGI_ENDPOINT = 'http://localhost:3000/api/digipeaters'
 
 // Initialize the Leaflet map
 const map = L.map('map').setView([39.0, -78.3], 7); // Centering on Dulles Airport
@@ -68,5 +69,25 @@ fetch(GMRS_ENDPOINT)
             markers.addLayer(marker); // Add marker to the cluster
         });
         map.addLayer(markers); // Add cluster layer to map
+    })
+    .catch(error => console.error('Error fetching data:', error));
+
+fetch(DIGI_ENDPOINT)
+    .then(response => response.json())
+    .then(data => {
+        data.forEach(repeater => {
+            const { _id, type, id, geometry, coordinates, geometry_name, properties, parent_call, call, lastheard, grid, heard, ssid, last_port, uid, ports } = repeater;
+
+            const marker = L.circleMarker([geometry.coordinates[1], geometry.coordinates[0]], {
+                radius: 8, fillColor: "#008000", color: "#000000",
+                weight: 1, opacity: 1, fillOpacity: 0.8
+            }).bindPopup(
+                `<strong>${call || "Name Unknown"}</strong><br>
+                Frequency: ${ports}<br>
+                Grid: ${grid}<br>
+            `); // Add a popup with digirepeater info
+            
+            markers.addLayer(marker); // Add marker to the cluster
+        })
     })
     .catch(error => console.error('Error fetching data:', error));

--- a/js/main.js
+++ b/js/main.js
@@ -33,7 +33,7 @@ fetch(HAM_ENDPOINT)
             // Create a marker for each repeater
             const marker = L.circleMarker([lat, lon], {
                 radius: 8,
-                fillColor: "red",
+                fillColor: "blue",
                 color: "black",
                 weight: 1,
                 opacity: 1,
@@ -61,7 +61,7 @@ fetch(GMRS_ENDPOINT)
 
             const marker = L.circleMarker([Latitude, Longitude], {
                 radius: 8,
-                fillColor: "blue",
+                fillColor: "red",
                 color: "black",
                 weight: 1,
                 opacity: 1,

--- a/js/main.js
+++ b/js/main.js
@@ -75,14 +75,35 @@ fetch(GMRS_ENDPOINT)
 fetch(DIGI_ENDPOINT)
     .then(response => response.json())
     .then(data => {
-        data.forEach(repeater => {
-            L.geoJSON(data, {
-                onEachFeature: function (feature, layer) {
-                    // Create the popup content
-                    const popupContent = `<strong>Call Sign:</strong> ${feature.properties.call}`;
-                    layer.bindPopup(popupContent);  
-                }
-            }).addTo(map);
+        // Use L.geoJSON to plot the data on the map and add popups to the marker cluster
+        L.geoJSON(data, {
+            onEachFeature: function (feature, layer) {
+              // Check if properties are available
+              if (feature.properties) {
+                // Create a popup content from digipeater properties
+                const popupContent = `
+                  <strong>Call Sign:</strong> ${feature.properties.call}<br>
+                  <strong>Last Heard:</strong> ${feature.properties.lastheard}<br>
+                  <strong>Port:</strong> ${feature.properties.ports}<br>
+                  <strong>Grid:</strong> ${feature.properties.grid}<br>
+                  <strong>SSID:</strong> ${feature.properties.ssid || 'N/A'}<br>
+                  <strong>Heard:</strong> ${feature.properties.heard ? 'Yes' : 'No'}
+                `;
+                layer.bindPopup(popupContent); // Bind the popup to the marker
+              }
+  
+              markers.addLayer(layer); // Add the layer to the MarkerClusterGroup
+            },
+            pointToLayer: function (feature, latlng) {
+                return L.circleMarker(latlng, {
+                  radius: 8,
+                  color: 'orange',
+                  weight: 1,
+                  opacity: 1,
+                  fillOpacity: 0.8
+                });
+              }
+          });
+          map.addLayer(markers); // Add the MarkerClusterGroup to the map
         })
-    })
     .catch(error => console.error('Error fetching data:', error));

--- a/js/main.js
+++ b/js/main.js
@@ -85,24 +85,23 @@ fetch(DIGI_ENDPOINT)
     .then(data => {
         // Use L.geoJSON to plot the data on the map and add popups to the marker cluster
         L.geoJSON(data, {
-            onEachFeature: function (feature, layer) {
+            onEachFeature: function (digipeater, digi_layer) {
               // Check if properties are available
-              if (feature.properties) {
+              if (digipeater.properties) {
                 // Create a popup content from digipeater properties
                 const popupContent = `
-                  <strong>${feature.properties.call}</strong><br>
-                  Last Heard: ${feature.properties.lastheard}<br>
-                  Port: ${feature.properties.ports}<br>
-                  Grid: ${feature.properties.grid}<br>
-                  SSID: ${feature.properties.ssid || 'N/A'}<br>
-                  Heard: ${feature.properties.heard ? 'Yes' : 'No'}
+                  <strong>${digipeater.properties.call}</strong><br>
+                  Last Heard: ${digipeater.properties.lastheard}<br>
+                  Last Port: ${digipeater.properties.last_port}<br>
+                  Grid: ${digipeater.properties.grid}<br>
+                  SSID: ${digipeater.properties.ssid || 'N/A'}<br>
+                  Heard: ${digipeater.properties.heard ? 'Yes' : 'No'}
                 `;
-                layer.bindPopup(popupContent); // Bind the popup to the marker
+                digi_layer.bindPopup(popupContent); // Bind the popup to the marker
               }
-  
-              markers.addLayer(layer); // Add the layer to the MarkerClusterGroup
+              markers.addLayer(digi_layer); // Add the digi_layer to the MarkerClusterGroup
             },
-            pointToLayer: function (feature, latlng) {
+            pointToLayer: function (digipeater, latlng) {
                 return L.circleMarker(latlng, {
                   radius: 8,
                   color: 'black',

--- a/js/main.js
+++ b/js/main.js
@@ -76,18 +76,13 @@ fetch(DIGI_ENDPOINT)
     .then(response => response.json())
     .then(data => {
         data.forEach(repeater => {
-            const { _id, type, id, geometry, coordinates, geometry_name, properties, parent_call, call, lastheard, grid, heard, ssid, last_port, uid, ports } = repeater;
-
-            const marker = L.circleMarker([geometry.coordinates[1], geometry.coordinates[0]], {
-                radius: 8, fillColor: "#008000", color: "#000000",
-                weight: 1, opacity: 1, fillOpacity: 0.8
-            }).bindPopup(
-                `<strong>${call || "Name Unknown"}</strong><br>
-                Frequency: ${ports}<br>
-                Grid: ${grid}<br>
-            `); // Add a popup with digirepeater info
-            
-            markers.addLayer(marker); // Add marker to the cluster
+            L.geoJSON(data, {
+                onEachFeature: function (feature, layer) {
+                    // Create the popup content
+                    const popupContent = `<strong>Call Sign:</strong> ${feature.properties.call}`;
+                    layer.bindPopup(popupContent);  
+                }
+            }).addTo(map);
         })
     })
     .catch(error => console.error('Error fetching data:', error));

--- a/js/server.js
+++ b/js/server.js
@@ -1,5 +1,6 @@
 const HAM_DATA = '/api/ham_repeaters'
 const GMRS_DATA = '/api/gmrs_repeaters'
+const DIGI_DATA = '/api/digipeaters'
 
 const express = require('express');
 const mongoose = require('mongoose');
@@ -49,14 +50,49 @@ const gmrsSchema = new mongoose.Schema({
     node: { type: mongoose.Schema.Types.String, required: false },
 });
 
+
+// Define the schema for the "properties" object
+const digiPropsSchema = new mongoose.Schema({
+    id: { type: Number, required: true },
+    parent_call: { type: String, required: true },
+    call: { type: String, required: true },
+    lastheard: { type: Date, required: true },
+    grid: { type: String, required: true },
+    heard: { type: Boolean, required: true },
+    ssid: { type: String, default: null },
+    last_port: { type: String, required: true },
+    uid: { type: String, required: true },
+    ports: { type: String, required: true },
+});
+  
+// Define the schema for the "geometry" object
+const geometrySchema = new Schema({
+    type: { type: String, required: true },
+    coordinates: {
+      type: [Number], // Array of numbers representing the coordinates
+      required: true,
+    },
+});
+  
+// Define the main schema
+const digiSchema = new Schema({
+    _id: { type: mongoose.Schema.Types.ObjectId, required: true },
+    type: { type: String, required: true },
+    id: { type: String, required: true },
+    geometry: { type: geometrySchema, required: true },
+    geometry_name: { type: String, required: true },
+    properties: { type: propertiesSchema, required: true },
+});
+
 // Create models
 const hamModel = mongoose.model('hamrepeaters', hamSchema)
 const gmrsModel = mongoose.model('gmrsrepeaters', gmrsSchema)
+const digiModel = mongoose.model('digipeaters', digiSchema)
 
 // Route to read ham repeater data
 app.get(HAM_DATA, async (req, result) => {
     try {
-        const data = await hamModel.find(); // Fetch all documents
+        const data = await hamModel.find(); // Fetch Ham repeaters
         result.json(data);
     } catch (error) {
         result.status(500).json({ message: error.message });
@@ -66,12 +102,21 @@ app.get(HAM_DATA, async (req, result) => {
 // Route to read gmrs repeaters
 app.get(GMRS_DATA, async (req, result) => {
     try {
-        const data = await gmrsModel.find(); // Fetch all documents
+        const data = await gmrsModel.find(); // Fetch all GMRS repeaters
         result.json(data);
     } catch (error) {
         result.status(500).json({ message: error.message });
     }
 });
+
+app.get(DIGI_DATA, async (req, result) => {
+    try {
+        const data = await digiModel.find(); // Fetch all digipeaters
+        result.json(data);
+    } catch (error) {
+        result.status(500).json({ message: error.message });
+    }
+})
 
 app.listen(PORT, () => {
     console.log(`Server running on http://localhost:${PORT}`);

--- a/js/server.js
+++ b/js/server.js
@@ -66,7 +66,7 @@ const digiPropsSchema = new mongoose.Schema({
 });
   
 // Define the schema for the "geometry" object
-const geometrySchema = new Schema({
+const geometrySchema = new mongoose.Schema({
     type: { type: String, required: true },
     coordinates: {
       type: [Number], // Array of numbers representing the coordinates
@@ -75,13 +75,13 @@ const geometrySchema = new Schema({
 });
   
 // Define the main schema
-const digiSchema = new Schema({
+const digiSchema = new mongoose.Schema({
     _id: { type: mongoose.Schema.Types.ObjectId, required: true },
     type: { type: String, required: true },
     id: { type: String, required: true },
     geometry: { type: geometrySchema, required: true },
     geometry_name: { type: String, required: true },
-    properties: { type: propertiesSchema, required: true },
+    properties: { type: digiPropsSchema, required: true },
 });
 
 // Create models


### PR DESCRIPTION
What does this PR do?

- This PR integrated a new data source for digipeaters
  - Loaded GeoJSON data to MongoDB (no code changes
  - Added endpoint to the express server
  - Loaded the digipeater data to the UI
- Also added GIF of UI to README.md

Why is this change being made?

- This change is being made so that Signal Scout users can find digipeaters in their area for purposes of digital packet transmission and reception, including APRS activities.